### PR TITLE
docs: update README formats table to include ODS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Apache POI requires **45+ lines** to do what Sheetz does in **1**. Here's the pr
 | **Annotation mapping** | ✅ | ❌ | ✅ | ❌ |
 | **Built-in validation** | ✅ | ❌ | ❌ | ❌ |
 | **Auto type conversion** | ✅ 19 types | ❌ | ⚠️ basic | ❌ |
-| **Multi-format (xlsx/xls/csv)** | ✅ | ✅ | ⚠️ xlsx only | ⚠️ xlsx only |
+| **Multi-format (xlsx/xls/csv/ods)** | ✅ | ✅ | ⚠️ xlsx only | ⚠️ xlsx only |
 
 📊 [Full JMH benchmark results & methodology →](https://github.com/chitralabs/sheetz-benchmarks)
 


### PR DESCRIPTION
## Summary
- Updated the comparison table to include ODS in the multi-format row (`xlsx/xls/csv` → `xlsx/xls/csv/ods`), reflecting the ODS support added in v1.0.2

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)