### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Sheetz follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.1.0] — 2026-06-16
+
 ### Added
 
 - **Cell Formatting API** — New `@Style` annotation for controlling cell visual presentation (fonts, colors, borders, alignment, text wrapping, data formats).
@@ -102,7 +106,8 @@ Sheetz follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-[Unreleased]: https://github.com/chitralabs/sheetz/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/chitralabs/sheetz/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/chitralabs/sheetz/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/chitralabs/sheetz/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/chitralabs/sheetz/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/chitralabs/sheetz/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Apache POI requires **45+ lines** to do what Sheetz does in **1**. Here's the pr
 <dependency>
     <groupId>io.github.chitralabs.sheetz</groupId>
     <artifactId>sheetz-core</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'io.github.chitralabs.sheetz:sheetz-core:1.0.2'
+implementation 'io.github.chitralabs.sheetz:sheetz-core:1.1.0'
 ```
 
 ### Define your model

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.chitralabs.sheetz</groupId>
     <artifactId>sheetz-core</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>Sheetz</name>


### PR DESCRIPTION
## Summary
- Bump version from 1.0.2 to 1.1.0 for the cell formatting API and ODS support release
- Update Maven/Gradle dependency snippets in README
- Move CHANGELOG [Unreleased] content under [1.1.0]

## Test plan
- [ ] Verify `mvn clean verify` passes
- [ ] Deploy to Maven Central with `mvn clean deploy -Prelease`

🤖 Generated with [Claude Code](https://claude.com/claude-code)