### PR TITLE
docs: SEO-optimized multi-page docs site with auto-deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,36 @@
 title: Sheetz
-description: Read and write Excel, CSV, and ODS files in Java with a single line of code.
+tagline: "Java Excel, CSV & ODS Library"
+description: >-
+  Read and write Excel (XLSX, XLS), CSV, and ODS files in Java with one line of code.
+  Annotation-based mapping, SAX streaming for million-row files, built-in validation,
+  19 automatic type converters. A modern, high-performance alternative to Apache POI.
+url: "https://chitralabs.github.io"
+baseurl: "/sheetz"
 remote_theme: pages-themes/cayman@v0.2.0
+
 plugins:
   - jekyll-remote-theme
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+author: chitralabs
+twitter:
+  card: summary
+social:
+  name: Chitralabs
+  links:
+    - https://github.com/chitralabs
+
+# google_analytics: G-XXXXXXXXXX
+
+header_pages:
+  - index.md
+  - migration-from-poi.md
+  - benchmarks.md
+  - faq.md
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% seo %}
+  <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
+  <!--[if lt IE 9]>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+  <![endif]-->
+  {% if site.google_analytics %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{ site.google_analytics }}');
+  </script>
+  {% endif %}
+  <style>
+    .page-nav { text-align: center; padding: 0.5em 0; }
+    .page-nav a { margin: 0 1em; color: #fff; text-decoration: none; font-weight: bold; }
+    .page-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <header class="page-header" role="banner">
+    <h1 class="project-name">{{ page.title | default: site.title }}</h1>
+    <h2 class="project-tagline">{{ site.tagline | default: site.description }}</h2>
+    <a href="https://github.com/chitralabs/sheetz" class="btn">View on GitHub</a>
+    <a href="https://central.sonatype.com/artifact/io.github.chitralabs.sheetz/sheetz-core" class="btn">Maven Central</a>
+    <nav class="page-nav">
+      <a href="{{ '/' | relative_url }}">Home</a>
+      <a href="{{ '/migration-from-poi' | relative_url }}">Migration Guide</a>
+      <a href="{{ '/benchmarks' | relative_url }}">Benchmarks</a>
+      <a href="{{ '/faq' | relative_url }}">FAQ</a>
+    </nav>
+  </header>
+  <main id="content" class="main-content" role="main">
+    {{ content }}
+    <footer class="site-footer">
+      <span class="site-footer-owner"><a href="https://github.com/chitralabs/sheetz">Sheetz</a> is maintained by <a href="https://github.com/chitralabs">chitralabs</a>.</span>
+      <span class="site-footer-credits">Apache License 2.0</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: "Sheetz Performance Benchmarks - Java Excel Library Comparison"
+description: "JMH benchmark results comparing Sheetz vs Apache POI, EasyExcel, FastExcel, and Poiji. Write performance, read performance, and memory usage across 1K-100K rows."
+---
+
+## Performance Benchmarks
+
+Reproducible [JMH](https://openjdk.org/projects/code-tools/jmh/) benchmarks comparing Sheetz against Apache POI, EasyExcel, FastExcel, and Poiji.
+
+All source code: [sheetz-benchmarks](https://github.com/chitralabs/sheetz-benchmarks)
+
+---
+
+### Write Performance (ms/op — lower is better)
+
+| Library | 1K rows | 10K rows | 100K rows |
+|---------|--------:|---------:|----------:|
+| FastExcel | 6.48 | 31.95 | 309.70 |
+| EasyExcel | 11.44 | 58.60 | 542.84 |
+| **Sheetz** | **23.15** | **232.51** | **423.75** |
+| Apache POI | 22.46 | 217.17 | 2,453.35 |
+
+At small sizes (1K-10K rows), Sheetz and Apache POI are similar. **At 100K rows, Sheetz is 5.8x faster** because it automatically switches to SXSSF streaming.
+
+```
+Write Performance — 100K rows (ms/op, lower is better)
+
+FastExcel   ||||||||                                309ms
+Sheetz      ||||||||||                              423ms  <-- auto SXSSF
+EasyExcel   |||||||||||||                           542ms
+Apache POI  ||||||||||||||||||||||||||||||||||||||  2453ms
+```
+
+---
+
+### Read Performance (ms/op — lower is better)
+
+| Library | 1K rows | 10K rows | 100K rows |
+|---------|--------:|---------:|----------:|
+| FastExcel | 2.43 | 24.88 | 210.17 |
+| EasyExcel | 4.91 | 42.66 | 334.17 |
+| Apache POI | 10.86 | 106.02 | 1,097.20 |
+| Poiji | 12.26 | 114.92 | 1,042.16 |
+| **Sheetz** | **13.18** | **128.35** | **1,285.89** |
+
+Sheetz read speed is comparable to Apache POI and Poiji. The difference from FastExcel/EasyExcel is the cost of automatic type conversion, annotation processing, and validation — features those libraries do not provide.
+
+---
+
+### Feature vs Performance Trade-off
+
+| Library | Code Lines (R+W) | Auto Types | Validation | Multi-Format |
+|---------|:-:|:-:|:-:|:-:|
+| **Sheetz** | **2** | 19 types | Built-in | xlsx/xls/csv/ods |
+| Apache POI | ~45 | None | None | xlsx/xls |
+| EasyExcel | ~15 | Basic | None | xlsx only |
+| FastExcel | ~33 | None | None | xlsx only |
+| Poiji | ~1 (read) | Basic | None | xlsx only |
+
+---
+
+### Methodology
+
+| Setting | Value |
+|---------|-------|
+| Framework | JMH 1.37 |
+| JVM | JDK 11.0.30, OpenJDK 64-Bit Server VM |
+| Hardware | Apple Silicon (macOS) |
+| Forks | 2 separate JVM processes |
+| Warmup | 3 iterations, 1s each |
+| Measurement | 5 iterations, 1s each |
+| Row counts | 1,000 / 10,000 / 100,000 |
+| Data | Fixed random seed for reproducibility |
+| Format | .xlsx (OOXML) for all libraries |
+
+Results vary by JVM, OS, and hardware. [Run the benchmarks yourself](https://github.com/chitralabs/sheetz-benchmarks#how-to-run) to get numbers for your environment.
+
+---
+
+### When to Choose Each Library
+
+- **Need minimal code + all features?** — Sheetz (1-line API, validation, 19 converters, 4 formats)
+- **Need maximum raw throughput?** — FastExcel (fastest reads and writes)
+- **Already using POI?** — Sheetz wraps POI, so it is a drop-in for new code
+- **Processing 1M+ rows, memory critical?** — `Sheetz.stream()` (~10MB constant) or FastExcel
+- **Need annotations + fast reads?** — EasyExcel (but requires listener pattern)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,145 @@
+---
+layout: default
+title: "Sheetz FAQ - Java Excel Library Questions & Answers"
+description: "Frequently asked questions about Sheetz, the Java library for reading and writing Excel, CSV, and ODS files. Setup, migration, performance, and troubleshooting."
+---
+
+## Frequently Asked Questions
+
+### General
+
+**Q: What file formats does Sheetz support?**
+
+Sheetz supports four formats: `.xlsx` (Excel 2007+), `.xls` (Excel 97-2003), `.csv`, and `.ods` (LibreOffice Calc). The API is identical for all formats — just change the file extension.
+
+**Q: What Java versions are supported?**
+
+Java 11 and above. Sheetz is tested on Java 11, 17, and 21 across Linux, macOS, and Windows.
+
+**Q: Is Sheetz thread-safe?**
+
+Yes. All static methods on `Sheetz` are fully thread-safe and can be called from multiple threads concurrently without synchronization.
+
+**Q: Is Sheetz free for commercial use?**
+
+Yes. Sheetz is licensed under the Apache License 2.0, which permits commercial use, modification, and distribution.
+
+---
+
+### Setup
+
+**Q: How do I add Sheetz to my Maven project?**
+
+```xml
+<dependency>
+    <groupId>io.github.chitralabs.sheetz</groupId>
+    <artifactId>sheetz-core</artifactId>
+    <version>1.1.0</version>
+</dependency>
+```
+
+**Q: How do I add Sheetz to my Gradle project?**
+
+```groovy
+implementation 'io.github.chitralabs.sheetz:sheetz-core:1.1.0'
+```
+
+**Q: Do I need Apache POI as a separate dependency?**
+
+No. Sheetz includes Apache POI 5.2.5 as a transitive dependency. You do not need to add POI separately.
+
+**Q: How do I enable ODS (LibreOffice) support?**
+
+Add the optional ODF Toolkit dependency:
+
+```xml
+<dependency>
+    <groupId>org.odftoolkit</groupId>
+    <artifactId>odfdom-java</artifactId>
+    <version>0.12.0</version>
+</dependency>
+```
+
+Without this dependency, calling `Sheetz.read("file.ods", ...)` will throw a clear error message explaining what to add.
+
+---
+
+### Performance
+
+**Q: How does Sheetz handle large files?**
+
+For reads, `Sheetz.stream()` uses SAX-based parsing with constant ~10MB memory regardless of file size. For writes, Sheetz automatically switches to Apache POI's SXSSF (streaming) mode for files larger than 10,000 rows.
+
+**Q: Is Sheetz faster than Apache POI?**
+
+For writes at scale, yes. At 100K rows, Sheetz writes are 5.8x faster than Apache POI because of automatic SXSSF streaming. For reads, Sheetz is comparable to POI while adding annotation mapping, type conversion, and validation. See [full benchmarks]({{ '/benchmarks' | relative_url }}).
+
+**Q: How does Sheetz compare to EasyExcel and FastExcel?**
+
+FastExcel and EasyExcel have faster raw throughput but require significantly more code and lack features like multi-format support, built-in validation, and automatic type conversion for 19 Java types. See the [benchmarks page]({{ '/benchmarks' | relative_url }}) for detailed comparisons.
+
+---
+
+### Migration
+
+**Q: Can I use Sheetz alongside Apache POI in the same project?**
+
+Yes. Sheetz uses POI internally, so they coexist. You can migrate incrementally — use Sheetz for new code and keep existing POI code unchanged. See the [migration guide]({{ '/migration-from-poi' | relative_url }}).
+
+**Q: Does Sheetz support all POI features?**
+
+Sheetz covers the most common use cases: typed read/write, streaming, validation, cell styling, hyperlinks, merged cells, auto-filters, and multi-sheet workbooks. For advanced POI features like formula evaluation or chart creation, you may still need POI directly. See the [roadmap](https://github.com/chitralabs/sheetz/blob/main/ROADMAP.md) for planned features.
+
+---
+
+### Troubleshooting
+
+**Q: I get "Unsupported format" for ODS files — what do I do?**
+
+Add the ODF Toolkit dependency to your project. See the ODS setup question above.
+
+**Q: My dates are not parsing correctly — how do I fix it?**
+
+Use the `@Column(format = "dd/MM/yyyy")` annotation to specify the date format in your source file. Sheetz supports `LocalDate`, `LocalDateTime`, `LocalTime`, `Instant`, and `ZonedDateTime`.
+
+**Q: How do I read from a specific sheet in a multi-sheet workbook?**
+
+Use the builder API:
+
+```java
+List<Product> data = Sheetz.reader(Product.class)
+    .file("report.xlsx")
+    .sheet("Inventory")
+    .read();
+```
+
+**Q: How do I style cells when writing?**
+
+Use the `@Style` annotation on your model fields:
+
+```java
+public class StyledProduct {
+    @Column("Product Name")
+    @Style(bold = true, fontColor = "#0000FF")
+    public String name;
+
+    @Style(backgroundColor = "#FFFF00", dataFormat = "#,##0.00")
+    public Double price;
+}
+```
+
+Or use the programmatic `CellStyleBuilder`:
+
+```java
+CellStyleDef style = CellStyleBuilder.create()
+    .bold(true)
+    .backgroundColor("#003366")
+    .fontColor("#FFFFFF")
+    .build();
+
+Sheetz.writer(Product.class)
+    .data(products)
+    .file("styled.xlsx")
+    .headerStyle(style)
+    .write();
+```

--- a/docs/migration-from-poi.md
+++ b/docs/migration-from-poi.md
@@ -1,0 +1,207 @@
+---
+layout: default
+title: "Migrate from Apache POI to Sheetz - Java Excel Migration Guide"
+description: "Step-by-step guide to migrate from Apache POI to Sheetz. Replace 45+ lines of boilerplate with 1-line API calls. Side-by-side code comparison."
+---
+
+## Migrate from Apache POI to Sheetz
+
+This guide shows how to replace Apache POI code with Sheetz, step by step.
+
+### Why Migrate?
+
+| | Apache POI | Sheetz |
+|---|---|---|
+| **Lines to read Excel** | 20+ | **1** |
+| **Lines to write Excel** | 25+ | **1** |
+| **Write 100K rows** | 2,453ms | **423ms (5.8x faster)** |
+| **Streaming memory** | ~340MB (manual config) | **~10MB (automatic)** |
+| **Type conversion** | Manual casting | **19 auto converters** |
+| **Validation** | DIY | **Built-in** |
+| **ODS support** | Limited | **Full read/write** |
+| **Learning curve** | Workbook > Sheet > Row > Cell | **One method call** |
+
+---
+
+### Step 1: Replace the Dependency
+
+Remove Apache POI:
+
+```xml
+<!-- REMOVE these -->
+<dependency>
+    <groupId>org.apache.poi</groupId>
+    <artifactId>poi</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.apache.poi</groupId>
+    <artifactId>poi-ooxml</artifactId>
+</dependency>
+```
+
+Add Sheetz:
+
+```xml
+<!-- ADD this -->
+<dependency>
+    <groupId>io.github.chitralabs.sheetz</groupId>
+    <artifactId>sheetz-core</artifactId>
+    <version>1.1.0</version>
+</dependency>
+```
+
+> **Note:** Sheetz uses Apache POI internally. You do not need POI as a direct dependency.
+
+---
+
+### Step 2: Replace Read Code
+
+**Before (Apache POI — 15 lines):**
+
+```java
+List<Product> products = new ArrayList<>();
+try (Workbook workbook = new XSSFWorkbook(new FileInputStream("products.xlsx"))) {
+    Sheet sheet = workbook.getSheetAt(0);
+    for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+        Row row = sheet.getRow(i);
+        if (row == null) continue;
+        Product p = new Product();
+        p.name = row.getCell(0).getStringCellValue();
+        p.price = row.getCell(1).getNumericCellValue();
+        p.inStock = row.getCell(2).getBooleanCellValue();
+        Cell dateCell = row.getCell(3);
+        if (dateCell != null) {
+            p.releaseDate = dateCell.getLocalDateTimeCellValue().toLocalDate();
+        }
+        products.add(p);
+    }
+}
+```
+
+**After (Sheetz — 1 line):**
+
+```java
+List<Product> products = Sheetz.read("products.xlsx", Product.class);
+```
+
+---
+
+### Step 3: Replace Write Code
+
+**Before (Apache POI — 25 lines):**
+
+```java
+try (Workbook workbook = new XSSFWorkbook()) {
+    Sheet sheet = workbook.createSheet("Products");
+    Row headerRow = sheet.createRow(0);
+    headerRow.createCell(0).setCellValue("name");
+    headerRow.createCell(1).setCellValue("price");
+    headerRow.createCell(2).setCellValue("inStock");
+    headerRow.createCell(3).setCellValue("releaseDate");
+    for (int i = 0; i < products.size(); i++) {
+        Row row = sheet.createRow(i + 1);
+        Product p = products.get(i);
+        row.createCell(0).setCellValue(p.name);
+        row.createCell(1).setCellValue(p.price);
+        row.createCell(2).setCellValue(p.inStock);
+        if (p.releaseDate != null) {
+            Cell cell = row.createCell(3);
+            cell.setCellValue(p.releaseDate);
+            CellStyle dateStyle = workbook.createCellStyle();
+            dateStyle.setDataFormat(
+                workbook.createDataFormat().getFormat("yyyy-mm-dd"));
+            cell.setCellStyle(dateStyle);
+        }
+    }
+    try (FileOutputStream fos = new FileOutputStream("output.xlsx")) {
+        workbook.write(fos);
+    }
+}
+```
+
+**After (Sheetz — 1 line):**
+
+```java
+Sheetz.write(products, "output.xlsx");
+```
+
+---
+
+### Step 4: Replace Streaming Code
+
+**Before (Apache POI SXSSF — manual configuration):**
+
+```java
+try (SXSSFWorkbook workbook = new SXSSFWorkbook(100)) {
+    Sheet sheet = workbook.createSheet("Products");
+    // ... same manual cell-by-cell code ...
+    workbook.write(new FileOutputStream("huge.xlsx"));
+    workbook.dispose(); // Clean up temp files
+}
+```
+
+**After (Sheetz — automatic streaming):**
+
+```java
+// Sheetz automatically uses SXSSF for files > 10K rows
+Sheetz.write(products, "huge.xlsx");
+
+// Or stream reads with constant ~10MB memory:
+try (StreamingReader<Product> reader = Sheetz.stream("huge.xlsx", Product.class)) {
+    for (Product p : reader) {
+        database.save(p);
+    }
+}
+```
+
+---
+
+### Step 5: Add Validation (New Capability)
+
+Apache POI has no built-in validation. With Sheetz:
+
+```java
+ValidationResult<Product> result = Sheetz.validate("data.xlsx", Product.class);
+result.errors().forEach(e ->
+    System.out.printf("Row %d [%s]: %s%n", e.row(), e.column(), e.message()));
+List<Product> validOnly = result.validRows();
+```
+
+---
+
+### Annotation Mapping Reference
+
+Replace manual cell-index mapping with annotations:
+
+```java
+public class Product {
+    @Column("Product Name")        // Map to header text
+    public String name;
+
+    @Column(index = 1)             // Map by column index
+    public Double price;
+
+    @Column(required = true)       // Fail validation if empty
+    public Boolean inStock;
+
+    @Column(format = "dd/MM/yyyy") // Custom date format
+    public LocalDate releaseDate;
+}
+```
+
+---
+
+### Compatibility Notes
+
+- **Java version**: Sheetz requires Java 11+. If you are on Java 8, you must upgrade first.
+- **POI interop**: Sheetz uses Apache POI 5.2.5 internally. If other parts of your codebase use POI directly, verify version compatibility.
+- **File formats**: Sheetz supports `.xlsx`, `.xls`, `.csv`, and `.ods`. The API is identical for all formats.
+- **Thread safety**: Unlike POI's Workbook objects, Sheetz static methods are fully thread-safe.
+
+---
+
+### Need Help Migrating?
+
+- [Full API documentation]({{ '/' | relative_url }})
+- [9 runnable examples](https://github.com/chitralabs/sheetz-examples)
+- [Ask a question](https://github.com/chitralabs/sheetz/discussions)


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow for automatic GitHub Pages deployment on push to main
- Created custom layout with navigation bar, `jekyll-seo-tag` for Open Graph/Twitter cards, canonical URLs, and Google Analytics placeholder
- Added **Apache POI Migration Guide** — side-by-side code comparisons targeting "apache poi alternative" searches (~500/mo)
- Added **JMH Benchmarks page** — full performance data with methodology, targeting "java excel library comparison" searches
- Added **FAQ page** — targeting long-tail searches like "java read excel file", "java excel streaming"
- Configured `jekyll-sitemap` plugin for automatic sitemap.xml generation

## SEO targets
| Query | Est. monthly volume | Page |
|-------|---:|------|
| "java excel library" | ~2,000 | index.md |
| "java read excel file" | ~3,000 | index.md, faq.md |
| "apache poi alternative" | ~500 | migration-from-poi.md |
| "java excel streaming" | ~400 | faq.md |

## Post-merge
- Change Pages source: Settings > Pages > Source > "GitHub Actions"
- Submit sitemap to Google Search Console (optional)

## Test plan
- [ ] Verify GitHub Pages deploys after merge
- [ ] Verify sitemap.xml is generated
- [ ] Check all 4 pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)